### PR TITLE
candidate-campaign integration

### DIFF
--- a/ecrmwa-backend/src/main/java/com/example/ecrmwabackend/model/Campaigns.java
+++ b/ecrmwa-backend/src/main/java/com/example/ecrmwabackend/model/Campaigns.java
@@ -1,7 +1,12 @@
 package com.example.ecrmwabackend.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import javax.persistence.*;
 import java.util.HashMap;
+import java.util.Objects;
 
 /*
 +-------------+--------------+------+-----+---------+-------+
@@ -25,11 +30,15 @@ public class Campaigns {
 
     @ManyToOne(fetch = FetchType.LAZY)
     //@Column(nullable = false)
+    @JsonIgnoreProperties(value = {"Campaigns", "hibernateLazyInitializer"})
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "id")
     private Candidate candidate;
 
     @ManyToOne(fetch = FetchType.LAZY)
     //@Column(nullable = false)
+    @JsonIgnoreProperties(value = {"Campaigns", "hibernateLazyInitializer"})
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "elecper_id")
     private Elecper elecper;
 
@@ -100,16 +109,56 @@ public class Campaigns {
 
     @Override
     public int hashCode() {
-        return super.hashCode();
+        int hash = 7;
+        hash = 79 * hash + Objects.hashCode(this.campaign_id);
+        hash = 79 * hash + Objects.hashCode(this.candidate);
+        hash = 79 * hash + Objects.hashCode(this.elecper);
+        hash = 79 * hash + Objects.hashCode(this.party);
+        hash = 79 * hash + Objects.hashCode(this.position);
+        hash = 79 * hash + Objects.hashCode(this.platform);
+        return hash;
     }
 
     @Override
     public boolean equals(Object obj) {
-        return super.equals(obj);
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Campaigns other = (Campaigns) obj;
+        if (!Objects.equals(this.candidate, other.candidate)) {
+            return false;
+        }
+        if (!Objects.equals(this.elecper, other.elecper)) {
+            return false;
+        }
+        if (!Objects.equals(this.party, other.party)) {
+            return false;
+        }
+        if (!Objects.equals(this.position, other.position)) {
+            return false;
+        }
+        if (!Objects.equals(this.platform, other.platform)) {
+            return false;
+        }
+        return Objects.equals(this.campaign_id, other.campaign_id);
     }
 
     @Override
     public String toString() {
-        return super.toString();
+        final StringBuilder sb = new StringBuilder("Campaigns{");
+        sb.append("campaign_id=").append(campaign_id);
+        sb.append(", candidate='").append(candidate).append('\'');
+        sb.append(", elecper='").append(elecper).append('\'');
+        sb.append(", party='").append(party).append('\'');
+        sb.append(", position='").append(position).append('\'');
+        sb.append(", platform='").append(platform).append('\'');
+        sb.append('}');
+        return sb.toString();
     }
 }

--- a/ecrmwa-backend/src/main/java/com/example/ecrmwabackend/model/Candidate.java
+++ b/ecrmwa-backend/src/main/java/com/example/ecrmwabackend/model/Candidate.java
@@ -1,46 +1,7 @@
 package com.example.ecrmwabackend.model;
 
 import javax.persistence.*;
-// <<<<<<< Campaign-Elecper
-// import java.util.List;
 
-
-// @Table(name = "candidate")
-// @Entity
-// public class Candidate {
-//     @Id
-//     @GeneratedValue(strategy = GenerationType.AUTO)
-//     @Column(name = "id", nullable = false)
-//     private Long id;
-
-//     public Long getId() {
-//         return id;
-//     }
-
-//     public void setId(Long id) {
-//         this.id = id;
-//     }
-
-//     @OneToMany(fetch = FetchType.LAZY, mappedBy = "candidate", orphanRemoval = true)
-//     private List<Campaigns> campaigns;
-
-//     public Candidate() {
-//     }
-
-//     public Candidate(Long id, List<Campaigns> campaigns) {
-//         this.id = id;
-//         this.campaigns = campaigns;
-//     }
-
-//     public List<Campaigns> getCampaigns() {
-//         return campaigns;
-//     }
-
-//     public void setCampaigns(List<Campaigns> campaigns) {
-//         this.campaigns = campaigns;
-//     }
-// }
-// =======
 import java.util.Date;
 import java.util.Objects;
 

--- a/ecrmwa-backend/src/main/java/com/example/ecrmwabackend/model/Elecper.java
+++ b/ecrmwa-backend/src/main/java/com/example/ecrmwabackend/model/Elecper.java
@@ -2,7 +2,7 @@ package com.example.ecrmwabackend.model;
 
 import javax.persistence.*;
 import java.time.LocalDate;
-import java.util.List;
+import java.util.Objects;
 
 //AUTOMATICALLY CREATED TABLE DEETS
 /*
@@ -29,19 +29,15 @@ public class Elecper {
     LocalDate fdate;
     boolean archived;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "elecper", orphanRemoval = true)
-    private List<Campaigns> campaigns;
-
     public Elecper() {
     }
 
-    public Elecper(Long elecper_id, String name, LocalDate sdate, LocalDate fdate, boolean archived, List<Campaigns> campaigns) {
+    public Elecper(Long elecper_id, String name, LocalDate sdate, LocalDate fdate, boolean archived) {
         this.elecper_id = elecper_id;
         this.name = name;
         this.sdate = sdate;
         this.fdate = fdate;
         this.archived = archived;
-        this.campaigns = campaigns;
     }
 
     public Long getElecper_id() {
@@ -84,27 +80,53 @@ public class Elecper {
         this.archived = archived;
     }
 
-    public List<Campaigns> getCampaigns() {
-        return campaigns;
-    }
-
-    public void setCampaigns(List<Campaigns> campaigns) {
-        this.campaigns = campaigns;
-    }
-
-
     @Override
     public int hashCode() {
-        return super.hashCode();
+        int hash = 7;
+        hash = 79 * hash + Objects.hashCode(this.elecper_id);
+        hash = 79 * hash + Objects.hashCode(this.name);
+        hash = 79 * hash + Objects.hashCode(this.sdate);
+        hash = 79 * hash + Objects.hashCode(this.fdate);
+        hash = 79 * hash + Objects.hashCode(this.archived);
+        return hash;
     }
 
     @Override
     public boolean equals(Object obj) {
-        return super.equals(obj);
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Elecper other = (Elecper) obj;
+        if (!Objects.equals(this.archived, other.archived)) {
+            return false;
+        }
+        if (!Objects.equals(this.fdate, other.fdate)) {
+            return false;
+        }
+        if (!Objects.equals(this.sdate, other.sdate)) {
+            return false;
+        }
+        if (!Objects.equals(this.name, other.name)) {
+            return false;
+        }
+        return Objects.equals(this.elecper_id, other.elecper_id);
     }
 
     @Override
     public String toString() {
-        return super.toString();
+        final StringBuilder sb = new StringBuilder("Elecper{");
+        sb.append("elecper_id=").append(elecper_id);
+        sb.append(", name='").append(name).append('\'');
+        sb.append(", sdate='").append(sdate).append('\'');
+        sb.append(", fdate='").append(fdate).append('\'');
+        sb.append(", archived='").append(archived).append('\'');
+        sb.append('}');
+        return sb.toString();
     }
 }

--- a/ecrmwa-backend/src/main/java/com/example/ecrmwabackend/repository/CandidateRepository.java
+++ b/ecrmwa-backend/src/main/java/com/example/ecrmwabackend/repository/CandidateRepository.java
@@ -1,14 +1,7 @@
 package com.example.ecrmwabackend.repository;
 
 import com.example.ecrmwabackend.model.Candidate;
-// <<<<<<< Campaign-Elecper
-// import org.springframework.data.repository.CrudRepository;
-// import org.springframework.stereotype.Repository;
 
-// @Repository
-// public interface CandidateRepository extends CrudRepository<Candidate, Long> {
-
-// =======
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;

--- a/ecrmwa-backend/src/main/java/com/example/ecrmwabackend/service/CandidateService.java
+++ b/ecrmwa-backend/src/main/java/com/example/ecrmwabackend/service/CandidateService.java
@@ -3,24 +3,7 @@ package com.example.ecrmwabackend.service;
 import com.example.ecrmwabackend.model.Candidate;
 import com.example.ecrmwabackend.repository.CandidateRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-// <<<<<<< Campaign-Elecper
-// import org.springframework.data.repository.CrudRepository;
-// import org.springframework.stereotype.Service;
 
-// import java.util.Optional;
-
-// @Service
-// public class CandidateService {
-//     @Autowired
-//     private CandidateRepository repository;
-
-//     public Candidate getCandidate(Long id) {
-//         Optional optional = repository.findById(id);
-//         if(optional.isEmpty())
-//             return null;
-//         else
-//             return (Candidate) optional.get();
-// =======
 import org.springframework.stereotype.Service;
 
 import java.util.List;


### PR DESCRIPTION
integrated candidates with campaigns

changed models from bi-directional to unidirectional relationships. now only campaigns "knows" its relationship with candidates and elecper.

Also, deleting a candidate or elecper will also delete campaigns with fks to them.

deleted commented temporary candidates from earlier merge


nakisabay: updated hashcode, equals, toString methods of campaigns and elecper